### PR TITLE
fix: implement strict bool value reading

### DIFF
--- a/hbapp-honeybadger-plugin.php
+++ b/hbapp-honeybadger-plugin.php
@@ -12,8 +12,8 @@
  * Plugin URI:        https://github.com/honeybadger-io/honeybadger-wordpress
  * Description:       Honeybadger error (PHP and JavaScript) reporting for WordPress.
  * Tags:              honeybadger, error monitoring, exception tracking, error tracking, bug tracking, error reporting, exception reporting, bug reporting
- * Version:           0.1.0
- * Tested up to:      6.7
+ * Version:           0.1.1
+ * Tested up to:      6.8
  * Requires at least: 5.3
  * Requires PHP:      7.3
  * Author:            Honeybadger Industries LLC

--- a/readme.txt
+++ b/readme.txt
@@ -33,9 +33,6 @@ More information on how the package is built can be found in the README file of 
 = I have installed the plugin but I can't see any notifications being reported. =
 Ensure that you have entered your Honeybadger API key(s) correctly in the plugin settings. Also, make sure that the "PHP error reporting enabled" and "JS error reporting enabled" options are checked. If you are still not seeing notifications, check your Honeybadger account to ensure that the API keys are valid and that there are no issues with your Honeybadger projects.
 
-= Why am I still seeing test notifications being reported to Honeybadger? =
-If you are seeing test notifications, it is likely that the "Send test notification" options are still checked in the plugin settings. Uncheck these options and click Save to stop sending test notifications.
-
 = What is the "Version" option? =
 The "Version" option allows you to specify the version of your application that is being monitored. This can be useful for tracking errors across different versions of your application.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Honeybadger Application Monitoring ===
 Contributors: pangratioscosma
 Tags: honeybadger, error monitoring, error reporting, exception reporting, bug reporting
-Stable tag: 0.1.0
-Tested up to: 6.7
+Stable tag: 0.1.1
+Tested up to: 6.8
 Requires at least: 5.3
 Requires PHP: 7.3
 License: GPL v2 or later

--- a/src/hbapp-honeybadger.php
+++ b/src/hbapp-honeybadger.php
@@ -219,13 +219,13 @@ class HBAPP_Honeybadger {
             'hbapp_honeybadger_js_send_test_notification' => 0,
         ]);
 
-        $this->php_reporting_enabled = $wpOptions['hbapp_honeybadger_php_enabled'] == 1;
+        $this->php_reporting_enabled = $wpOptions['hbapp_honeybadger_php_enabled'] === 1;
         $this->php_api_key = $wpOptions['hbapp_honeybadger_php_api_key'];
-        $this->php_send_test_notification = $wpOptions['hbapp_honeybadger_php_send_test_notification'] == 1;
+        $this->php_send_test_notification = $wpOptions['hbapp_honeybadger_php_send_test_notification'] === 1;
 
-        $this->js_reporting_enabled = $wpOptions['hbapp_honeybadger_js_enabled'] == 1;
+        $this->js_reporting_enabled = $wpOptions['hbapp_honeybadger_js_enabled'] === 1;
         $this->js_api_key = $wpOptions['hbapp_honeybadger_js_api_key'];
-        $this->js_send_test_notification = $wpOptions['hbapp_honeybadger_js_send_test_notification'] == 1;
+        $this->js_send_test_notification = $wpOptions['hbapp_honeybadger_js_send_test_notification'] === 1;
 
         $hbConfigFromWp = [];
         if (!empty($wpOptions['hbapp_honeybadger_endpoint'])) {
@@ -247,7 +247,7 @@ class HBAPP_Honeybadger {
      * @param array $settings Associative array of settings to update
      * @return bool True if settings were updated successfully, false otherwise
      */
-    public function update_settings($settings) {
+    private function update_settings($settings) {
         if (!is_array($settings) || empty($settings)) {
             return false;
         }

--- a/src/hbapp-honeybadger.php
+++ b/src/hbapp-honeybadger.php
@@ -99,6 +99,7 @@ class HBAPP_Honeybadger {
 
         if ($this->php_send_test_notification) {
             $this->client->notify(new Exception('Test PHP error from WordPress Honeybadger plugin.'));
+            $this->update_settings(['hbapp_honeybadger_php_send_test_notification' => 0]);
         }
     }
 
@@ -173,6 +174,7 @@ class HBAPP_Honeybadger {
 
         if ($this->js_send_test_notification) {
             wp_add_inline_script('hbapp_honeybadger_js', 'Honeybadger.notify("Test JavaScript error from WordPress Honeybadger plugin.");');
+            $this->update_settings(['hbapp_honeybadger_js_send_test_notification' => 0]);
         }
     }
 
@@ -198,6 +200,13 @@ class HBAPP_Honeybadger {
         // setup settings page
         new HBAPP_HoneybadgerSettings();
 
+        $this->load_settings_from_options();
+    }
+
+    /**
+     * Load settings from WordPress Options API and initialize instance variables
+     */
+    private function load_settings_from_options() {
         $wpOptions = get_option('hbapp_honeybadger_settings', [
             'hbapp_honeybadger_php_enabled' => 1,
             'hbapp_honeybadger_php_api_key' => '',
@@ -210,13 +219,13 @@ class HBAPP_Honeybadger {
             'hbapp_honeybadger_js_send_test_notification' => 0,
         ]);
 
-        $this->php_reporting_enabled = $wpOptions['hbapp_honeybadger_php_enabled'];
+        $this->php_reporting_enabled = $wpOptions['hbapp_honeybadger_php_enabled'] == 1;
         $this->php_api_key = $wpOptions['hbapp_honeybadger_php_api_key'];
-        $this->php_send_test_notification = $wpOptions['hbapp_honeybadger_php_send_test_notification'];
+        $this->php_send_test_notification = $wpOptions['hbapp_honeybadger_php_send_test_notification'] == 1;
 
-        $this->js_reporting_enabled = $wpOptions['hbapp_honeybadger_js_enabled'];
+        $this->js_reporting_enabled = $wpOptions['hbapp_honeybadger_js_enabled'] == 1;
         $this->js_api_key = $wpOptions['hbapp_honeybadger_js_api_key'];
-        $this->js_send_test_notification = $wpOptions['hbapp_honeybadger_js_send_test_notification'];
+        $this->js_send_test_notification = $wpOptions['hbapp_honeybadger_js_send_test_notification'] == 1;
 
         $hbConfigFromWp = [];
         if (!empty($wpOptions['hbapp_honeybadger_endpoint'])) {
@@ -230,5 +239,29 @@ class HBAPP_Honeybadger {
         }
 
         $this->config = new \Honeybadger\Config($hbConfigFromWp);
+    }
+
+    /**
+     * Update specific settings in the WordPress Options API and refresh instance variables
+     *
+     * @param array $settings Associative array of settings to update
+     * @return bool True if settings were updated successfully, false otherwise
+     */
+    public function update_settings($settings) {
+        if (!is_array($settings) || empty($settings)) {
+            return false;
+        }
+
+        $wpOptions = get_option('hbapp_honeybadger_settings', []);
+        foreach ($settings as $key => $value) {
+            $wpOptions[$key] = $value;
+        }
+
+        $updated = update_option('hbapp_honeybadger_settings', $wpOptions);
+        if ($updated) {
+            $this->load_settings_from_options();
+        }
+
+        return $updated;
     }
 }


### PR DESCRIPTION
We received a report that test notifications were being sent even when the Send Test Notification checkboxes were unchecked.

This PR introduces:
- [x] a stricter version of reading the value
- [x] immediately updates the option to unset it's value after the test notification is sent

Bonus:
- [x] I tested against v6.8.2 (latest version).