### PR TITLE
feat: add options to ignore non-fatal errors

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -9,6 +9,7 @@ readme.md
 
 # Plugin Testing files
 tests
+bin
 .phpcs.xml.dist
 .phpunit.result.cache
 php-build.ini

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,8 @@ jobs:
       - name: Install dependencies
         uses: php-actions/composer@master
         with:
+          dev: no
+          args: --prefer-dist --optimize-autoloader
           php_version: '8.4'
 
       - name: Deploy

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then:
 A working WordPress installation is necessary to use the plugin during development.  
 Once WordPress is up and running:
 - Run `composer install` in the plugin folder to install dependencies
-- Run `ln -s /absolute/path/to/honeybadger-wordpress /absolute/path/to/wordpress/wp-content/plugins/honeybadger-application/monitoring`
+- Run `ln -s /absolute/path/to/honeybadger-wordpress /absolute/path/to/wordpress/wp-content/plugins/honeybadger-application-monitoring`
 
 Now any changes to the plugin code will be reflected immediately in your local WordPress installation.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Then:
 3. Push a new tag to the repository with the new version number.
 4. The previous step should trigger the GitHub Actions workflow to build the plugin and deploy it to the WordPress Plugin Directory.
 
+## Local Development
+
+A working WordPress installation is necessary to use the plugin during development.  
+Once WordPress is up and running:
+- Run `composer install` in the plugin folder to install dependencies
+- Run `ln -s /absolute/path/to/honeybadger-wordpress /absolute/path/to/wordpress/wp-content/plugins/honeybadger-application/monitoring`
+
+Now any changes to the plugin code will be reflected immediately in your local WordPress installation.
+
 ## Support
 
 For issues and feature requests, please [create an issue](https://github.com/honeybadger-io/honeybadger-wordpress/issues) on GitHub.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,10 +3,10 @@
 	bootstrap="tests/bootstrap.php"
 	backupGlobals="false"
 	colors="true"
-	convertErrorsToExceptions="true"
-	convertWarningsToExceptions="true"
-	convertNoticesToExceptions="true"
-	convertDeprecationsToExceptions="true"
+	convertErrorsToExceptions="false"
+	convertWarningsToExceptions="false"
+	convertNoticesToExceptions="false"
+	convertDeprecationsToExceptions="false"
 	>
 	<testsuites>
 		<testsuite name="testing">

--- a/src/hbapp-honeybadger-settings.php
+++ b/src/hbapp-honeybadger-settings.php
@@ -236,7 +236,6 @@ class HBAPP_HoneybadgerSettings {
         <?php
     }
 
-    // New renderers
     public function php_report_non_fatal_render() {
         $options = get_option('hbapp_honeybadger_settings');
         ?>
@@ -266,9 +265,11 @@ class HBAPP_HoneybadgerSettings {
     }
 
     public function settings_php_section_callback() {
+        // no-op
     }
 
     public function settings_js_section_callback() {
+        // no-op
     }
 
     public function options_page() {

--- a/src/hbapp-honeybadger-settings.php
+++ b/src/hbapp-honeybadger-settings.php
@@ -33,12 +33,19 @@ class HBAPP_HoneybadgerSettings {
             'honeybadger-application-monitoring'
         );
 
+        add_settings_section(
+                'hbapp_honeybadger_settings_php_section',
+                __('PHP Reporting Settings', 'honeybadger-application-monitoring'),
+                [$this, 'settings_php_section_callback'],
+                'honeybadger-application-monitoring'
+        );
+
         add_settings_field(
             'hbapp_honeybadger_php_enabled',
             __('PHP error reporting enabled', 'honeybadger-application-monitoring'),
             [$this, 'php_enabled_render'],
             'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
+            'hbapp_honeybadger_settings_php_section'
         );
 
         add_settings_field(
@@ -46,7 +53,38 @@ class HBAPP_HoneybadgerSettings {
             __('PHP API Key', 'honeybadger-application-monitoring'),
             [$this, 'php_api_key_render'],
             'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
+            'hbapp_honeybadger_settings_php_section'
+        );
+
+        add_settings_field(
+                'hbapp_honeybadger_php_report_non_fatal',
+                __('Report non-fatal PHP errors', 'honeybadger-application-monitoring'),
+                [$this, 'php_report_non_fatal_render'],
+                'honeybadger-application-monitoring',
+                'hbapp_honeybadger_settings_php_section'
+        );
+
+        add_settings_field(
+                'hbapp_honeybadger_php_capture_deprecations',
+                __('Report PHP deprecations', 'honeybadger-application-monitoring'),
+                [$this, 'php_capture_deprecations_render'],
+                'honeybadger-application-monitoring',
+                'hbapp_honeybadger_settings_php_section'
+        );
+
+        add_settings_field(
+                'hbapp_honeybadger_php_send_test_notification',
+                __('Send test notification from PHP', 'honeybadger-application-monitoring'),
+                [$this, 'php_send_test_notification_render'],
+                'honeybadger-application-monitoring',
+                'hbapp_honeybadger_settings_php_section'
+        );
+
+        add_settings_section(
+                'hbapp_honeybadger_settings_js_section',
+                __('JavaScript Reporting Settings', 'honeybadger-application-monitoring'),
+                [$this, 'settings_js_section_callback'],
+                'honeybadger-application-monitoring'
         );
 
         add_settings_field(
@@ -54,7 +92,7 @@ class HBAPP_HoneybadgerSettings {
             __('JS error reporting enabled', 'honeybadger-application-monitoring'),
             [$this, 'js_enabled_render'],
             'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
+            'hbapp_honeybadger_settings_js_section'
         );
 
         add_settings_field(
@@ -62,7 +100,7 @@ class HBAPP_HoneybadgerSettings {
             __('JS API Key', 'honeybadger-application-monitoring'),
             [$this, 'js_api_key_render'],
             'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
+            'hbapp_honeybadger_settings_js_section'
         );
 
         add_settings_field(
@@ -70,7 +108,7 @@ class HBAPP_HoneybadgerSettings {
             __('Environment', 'honeybadger-application-monitoring'),
             [$this, 'environment_name_render'],
             'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
+            'hbapp_honeybadger_settings_js_section'
         );
 
         add_settings_field(
@@ -78,15 +116,7 @@ class HBAPP_HoneybadgerSettings {
             __('Version', 'honeybadger-application-monitoring'),
             [$this, 'version_render'],
             'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
-        );
-
-        add_settings_field(
-            'hbapp_honeybadger_php_send_test_notification',
-            __('Send test notification from PHP', 'honeybadger-application-monitoring'),
-            [$this, 'php_send_test_notification_render'],
-            'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
+            'hbapp_honeybadger_settings_js_section'
         );
 
         add_settings_field(
@@ -94,7 +124,7 @@ class HBAPP_HoneybadgerSettings {
             __('Send test notification from JavaScript', 'honeybadger-application-monitoring'),
             [$this, 'js_send_test_notification_render'],
             'honeybadger-application-monitoring',
-            'hbapp_honeybadger_settings_section'
+            'hbapp_honeybadger_settings_js_section'
         );
     }
 
@@ -135,6 +165,8 @@ class HBAPP_HoneybadgerSettings {
         $settings['hbapp_honeybadger_js_api_key'] = $this->sanitize_js_api_key($settings['hbapp_honeybadger_js_api_key']) ?? '';
         $settings['hbapp_honeybadger_environment_name'] = $this->sanitize_environment_name($settings['hbapp_honeybadger_environment_name'] ?? '');
         $settings['hbapp_honeybadger_version'] = $this->sanitize_version($settings['hbapp_honeybadger_version'] ?? '');
+        $settings['hbapp_honeybadger_php_report_non_fatal'] = $this->sanitize_bool_value($settings['hbapp_honeybadger_php_report_non_fatal'] ?? 0);
+        $settings['hbapp_honeybadger_php_capture_deprecations'] = $this->sanitize_bool_value($settings['hbapp_honeybadger_php_capture_deprecations'] ?? 0);
         return $settings;
     }
 
@@ -204,12 +236,39 @@ class HBAPP_HoneybadgerSettings {
         <?php
     }
 
+    // New renderers
+    public function php_report_non_fatal_render() {
+        $options = get_option('hbapp_honeybadger_settings');
+        ?>
+        <input type='checkbox' name='hbapp_honeybadger_settings[hbapp_honeybadger_php_report_non_fatal]' <?php checked($options['hbapp_honeybadger_php_report_non_fatal'] ?? 0, 1); ?> value='1'>
+        <span>
+            <?php echo esc_html__('When enabled, the plugin will report non-fatal PHP errors (warnings/notices).', 'honeybadger-application-monitoring'); ?>
+        </span>
+        <?php
+    }
+
+    public function php_capture_deprecations_render() {
+        $options = get_option('hbapp_honeybadger_settings');
+        ?>
+        <input type='checkbox' name='hbapp_honeybadger_settings[hbapp_honeybadger_php_capture_deprecations]' <?php checked($options['hbapp_honeybadger_php_capture_deprecations'] ?? 0, 1); ?> value='1'>
+        <span>
+            <?php echo esc_html__('When enabled, the plugin will report PHP deprecation warnings.', 'honeybadger-application-monitoring'); ?>
+        </span>
+        <?php
+    }
+
     public function settings_section_callback() {
         $this->logo();
         echo wp_kses('<br />', array('br' => array()));
         echo esc_html__('Configure your Honeybadger settings below.', 'honeybadger-application-monitoring');
         echo wp_kses('<br />', array('br' => array()));
         echo esc_html__('For optimum experience, it is recommended to setup two Honeybadger projects, one for PHP and another for JavaScript.', 'honeybadger-application-monitoring');
+    }
+
+    public function settings_php_section_callback() {
+    }
+
+    public function settings_js_section_callback() {
     }
 
     public function options_page() {

--- a/src/hbapp-honeybadger.php
+++ b/src/hbapp-honeybadger.php
@@ -147,7 +147,7 @@ class HBAPP_Honeybadger {
             try {
                 $this->client->notify(new Exception('Test PHP error from WordPress Honeybadger plugin.'));
             }
-            catch (Exception $e) {
+            catch (Throwable $e) {
                 wp_admin_notice('Honeybadger - Could not send test notification: ' . $e->getMessage(), ['type' => 'error']);
             }
         }

--- a/src/hbapp-honeybadger.php
+++ b/src/hbapp-honeybadger.php
@@ -266,7 +266,7 @@ class HBAPP_Honeybadger {
         $this->js_reporting_enabled = ($wpOptions['hbapp_honeybadger_js_enabled'] ?? 1) === 1;
         $this->js_api_key = $wpOptions['hbapp_honeybadger_js_api_key'] ?? '';
         $this->js_send_test_notification = ($wpOptions['hbapp_honeybadger_js_send_test_notification'] ?? 0) === 1;
-        $this->php_report_non_fatal = ($wpOptions['hbapp_honeybadger_php_report_non_fatal'] ?? 0) == 1;
+        $this->php_report_non_fatal = ($wpOptions['hbapp_honeybadger_php_report_non_fatal'] ?? 0) === 1;
 
         $hbConfigFromWp = [];
         if (!empty($wpOptions['hbapp_honeybadger_endpoint'])) {
@@ -279,7 +279,7 @@ class HBAPP_Honeybadger {
             $hbConfigFromWp['version'] = $wpOptions['hbapp_honeybadger_version'];
         }
 
-        $hbConfigFromWp['capture_deprecations'] = ($wpOptions['hbapp_honeybadger_php_capture_deprecations'] ?? 0) == 1;
+        $hbConfigFromWp['capture_deprecations'] = ($wpOptions['hbapp_honeybadger_php_capture_deprecations'] ?? 0) === 1;
 
         $this->config = new \Honeybadger\Config($hbConfigFromWp);
     }

--- a/src/hbapp-honeybadger.php
+++ b/src/hbapp-honeybadger.php
@@ -136,8 +136,13 @@ class HBAPP_Honeybadger {
         });
 
         if ($this->php_send_test_notification) {
-            $this->client->notify(new Exception('Test PHP error from WordPress Honeybadger plugin.'));
             $this->update_settings(['hbapp_honeybadger_php_send_test_notification' => 0]);
+            try {
+                $this->client->notify(new Exception('Test PHP error from WordPress Honeybadger plugin.'));
+            }
+            catch (Exception $e) {
+                wp_admin_notice('Honeybadger - Could not send test notification: ' . $e->getMessage(), ['type' => 'error']);
+            }
         }
     }
 
@@ -211,8 +216,8 @@ class HBAPP_Honeybadger {
         }
 
         if ($this->js_send_test_notification) {
-            wp_add_inline_script('hbapp_honeybadger_js', 'Honeybadger.notify("Test JavaScript error from WordPress Honeybadger plugin.");');
             $this->update_settings(['hbapp_honeybadger_js_send_test_notification' => 0]);
+            wp_add_inline_script('hbapp_honeybadger_js', 'Honeybadger.notify("Test JavaScript error from WordPress Honeybadger plugin.");');
         }
     }
 

--- a/src/hbapp-honeybadger.php
+++ b/src/hbapp-honeybadger.php
@@ -79,6 +79,13 @@ class HBAPP_Honeybadger {
         $config = array_merge($this->config->all(), [
             'api_key' => $this->php_api_key,
             'report_data' => $this->php_reporting_enabled,
+            'service_exception_handler' => function (Honeybadger\Exceptions\ServiceException $e) {
+                if (is_admin()) {
+                    // show an error message if we are in an Admin page
+                    wp_admin_notice($e->getMessage(), ['type' => 'error']);
+                }
+                error_log($e->getMessage() . ': ' . $e->getTraceAsString());
+            },
             'notifier' => [
                 'name' => 'honeybadger-wordpress',
                 'url' => 'https://github.com/honeybadger-io/honeybadger-wordpress',

--- a/tests/test-honeybadger-init.php
+++ b/tests/test-honeybadger-init.php
@@ -2,14 +2,14 @@
 
 class Honeybadger_Init_Test extends WP_UnitTestCase {
 
-    private $admin_user_id;
+    private $adminUserId;
 
-    public function setUp(): void {
+    public function set_up(): void {
         parent::setUp();
 
         // Ensure we run menu-related tests with a user who can manage options.
-        $this->admin_user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-        wp_set_current_user( $this->admin_user_id );
+        $this->adminUserId = $this->factory->user->create( [ 'role' => 'administrator' ] );
+        wp_set_current_user( $this->adminUserId );
 
         // Use an admin screen context so admin hooks behave as expected.
         if ( function_exists( 'set_current_screen' ) ) {
@@ -17,7 +17,7 @@ class Honeybadger_Init_Test extends WP_UnitTestCase {
         }
     }
 
-    public function tearDown(): void {
+    public function tear_down(): void {
         wp_set_current_user( 0 );
         parent::tearDown();
     }

--- a/tests/test-honeybadger-init.php
+++ b/tests/test-honeybadger-init.php
@@ -5,7 +5,7 @@ class Honeybadger_Init_Test extends WP_UnitTestCase {
     private $adminUserId;
 
     public function set_up(): void {
-        parent::setUp();
+        parent::set_up();
 
         // Ensure we run menu-related tests with a user who can manage options.
         $this->adminUserId = $this->factory->user->create( [ 'role' => 'administrator' ] );
@@ -19,7 +19,7 @@ class Honeybadger_Init_Test extends WP_UnitTestCase {
 
     public function tear_down(): void {
         wp_set_current_user( 0 );
-        parent::tearDown();
+        parent::tear_down();
     }
 
 

--- a/tests/test-honeybadger-settings.php
+++ b/tests/test-honeybadger-settings.php
@@ -2,19 +2,27 @@
 
 class Honeybadger_Settings_Test extends WP_UnitTestCase {
 
-    private $admin_user_id;
+    private $adminUserId;
 
-    public function setUp(): void {
-        parent::setUp();
+    public function set_up(): void {
+        parent::set_up();
 
         // Be admin for admin area hooks and capability checks.
-        $this->admin_user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-        wp_set_current_user( $this->admin_user_id );
+        $this->adminUserId = $this->factory->user->create( [ 'role' => 'administrator' ] );
+        wp_set_current_user( $this->adminUserId );
 
         // Use an admin screen context so admin hooks behave as expected.
         if ( function_exists( 'set_current_screen' ) ) {
             set_current_screen( 'options-general' );
         }
+    }
+
+    public function tear_down(): void {
+        // need to manually restore error and exception handlers that are registered by the honeybadger sdk
+        restore_error_handler();
+        restore_exception_handler();
+
+        parent::tear_down();
     }
 
     public function test_settings_page_renders_without_errors() {
@@ -35,6 +43,8 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         $this->assertStringContainsString( 'Honeybadger Settings', $output );
         $this->assertStringContainsString( "name='hbapp_honeybadger_settings[hbapp_honeybadger_php_enabled]'", $output );
         $this->assertStringContainsString( "name='hbapp_honeybadger_settings[hbapp_honeybadger_php_api_key]'", $output );
+        $this->assertStringContainsString( "name='hbapp_honeybadger_settings[hbapp_honeybadger_php_report_non_fatal]'", $output );
+        $this->assertStringContainsString( "name='hbapp_honeybadger_settings[hbapp_honeybadger_php_capture_deprecations]'", $output );
     }
 
     /**
@@ -122,5 +132,173 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         $this->assertSame( 1, $opts['hbapp_honeybadger_js_enabled'] );
         // Flag should be reset after enqueue added the inline notify() call.
         $this->assertSame( 0, $opts['hbapp_honeybadger_js_send_test_notification'] );
+    }
+
+    /**
+     * When capture_deprecations is enabled, E_USER_DEPRECATED should be reported.
+     * We use E_USER_DEPRECATED for portability across PHP versions in CI.
+     */
+    public function test_deprecation_reported_when_capture_deprecations_enabled() {
+        update_option( 'hbapp_honeybadger_settings', [
+            'hbapp_honeybadger_php_enabled' => 1,
+            'hbapp_honeybadger_php_api_key' => 'dummy-key',
+            'hbapp_honeybadger_php_report_non_fatal' => 0, // doesn't matter for deprecations
+            'hbapp_honeybadger_php_capture_deprecations' => 1,
+            // js defaults
+            'hbapp_honeybadger_js_enabled' => 0,
+            'hbapp_honeybadger_js_api_key' => '',
+            'hbapp_honeybadger_js_send_test_notification' => 0,
+        ] );
+
+        // Ensure deprecations are reported by PHP
+        $prev = error_reporting();
+        error_reporting( E_ALL );
+
+        $history = [];
+        add_filter('hbapp_honeybadger_http_client', function($client, $config) use (&$history) {
+            $mock = new \GuzzleHttp\Handler\MockHandler([
+                new \GuzzleHttp\Psr7\Response(201, [], json_encode(['id' => 'test']))
+            ]);
+            $handlerStack = \GuzzleHttp\HandlerStack::create($mock);
+
+            // Record all requests in $history so we can assert they were made.
+            $historyMiddleware = \GuzzleHttp\Middleware::history($history);
+            $handlerStack->push($historyMiddleware);
+
+            return new \GuzzleHttp\Client([
+                'handler' => $handlerStack,
+                'base_uri' => $config['endpoint'] ?? 'https://api.honeybadger.io/'
+            ]);
+        }, 10, 2);
+        $plugin = new HBAPP_Honeybadger();
+        $plugin->boot();
+
+        // Trigger a user deprecation (portable across PHP versions)
+        trigger_error( 'Test user deprecation', E_USER_DEPRECATED );
+
+        // Restore error_reporting
+        error_reporting( $prev );
+
+        $this->assertGreaterThanOrEqual( 1, count( $history ), 'Expected a deprecation to be reported to Honeybadger.' );
+        $this->assertSame( 'POST', $history[0]['request']->getMethod() );
+        $this->assertSame( '/v1/notices', $history[0]['request']->getUri()->getPath() );
+    }
+
+    /**
+     * When capture_deprecations is disabled, E_USER_DEPRECATED should NOT be reported.
+     */
+    public function test_deprecation_not_reported_when_capture_deprecations_disabled() {
+        update_option( 'hbapp_honeybadger_settings', [
+            'hbapp_honeybadger_php_enabled' => 1,
+            'hbapp_honeybadger_php_api_key' => 'dummy-key',
+            'hbapp_honeybadger_php_report_non_fatal' => 1, // irrelevant here
+            'hbapp_honeybadger_php_capture_deprecations' => 0,
+        ] );
+
+        $prev = error_reporting();
+        error_reporting( E_ALL );
+
+        $history = [];
+        add_filter( 'hbapp_honeybadger_http_client', function( $client, $config ) use ( &$history ) {
+            $mock = new \GuzzleHttp\Handler\MockHandler([
+            ]);
+            $stack = \GuzzleHttp\HandlerStack::create( $mock );
+            $stack->push( \GuzzleHttp\Middleware::history( $history ) );
+            return new \GuzzleHttp\Client([ 'handler' => $stack, 'base_uri' => $config['endpoint'] ?? 'https://api.honeybadger.io/' ]);
+        }, 10, 2 );
+
+        $plugin = new HBAPP_Honeybadger();
+        $plugin->boot();
+
+        trigger_error( 'Test user deprecation', E_USER_DEPRECATED );
+
+        error_reporting( $prev );
+
+        $this->assertCount( 0, $history, 'Did not expect deprecation to be reported when capture_deprecations is disabled.' );
+    }
+
+    /**
+     * When php_report_non_fatal is enabled, E_USER_WARNING should be reported.
+     */
+    public function test_warning_reported_when_non_fatal_enabled() {
+        update_option( 'hbapp_honeybadger_settings', [
+            'hbapp_honeybadger_php_enabled' => 1,
+            'hbapp_honeybadger_php_api_key' => 'dummy-key',
+            'hbapp_honeybadger_php_send_test_notification' => 0,
+            'hbapp_honeybadger_php_report_non_fatal' => 1,
+            'hbapp_honeybadger_php_capture_deprecations' => 0,
+            'hbapp_honeybadger_js_send_test_notification' => 0,
+        ] );
+
+        $prev = error_reporting();
+        error_reporting( E_ALL );
+
+        $history = [];
+        add_filter('hbapp_honeybadger_http_client', function($client, $config) use (&$history) {
+            $mock = new \GuzzleHttp\Handler\MockHandler([
+                new \GuzzleHttp\Psr7\Response(201, [], json_encode(['id' => 'test']))
+            ]);
+            $handlerStack = \GuzzleHttp\HandlerStack::create($mock);
+
+            // Record all requests in $history so we can assert they were made.
+            $historyMiddleware = \GuzzleHttp\Middleware::history($history);
+            $handlerStack->push($historyMiddleware);
+
+            return new \GuzzleHttp\Client([
+                'handler' => $handlerStack,
+                'base_uri' => $config['endpoint'] ?? 'https://api.honeybadger.io/'
+            ]);
+        }, 10, 2);
+        $plugin = new HBAPP_Honeybadger();
+        $plugin->boot();
+
+        trigger_error( 'Test user warning: report non-fatal is true', E_USER_WARNING );
+
+        error_reporting( $prev );
+
+        $this->assertSame( 1, count( $history ), 'Expected a single warning to be reported to Honeybadger.' );
+        $this->assertSame( 'POST', $history[0]['request']->getMethod() );
+        $this->assertSame( '/v1/notices', $history[0]['request']->getUri()->getPath() );
+    }
+
+    /**
+     * When php_report_non_fatal is disabled, E_USER_WARNING should NOT be reported.
+     */
+    public function test_warning_not_reported_when_non_fatal_disabled() {
+        update_option( 'hbapp_honeybadger_settings', [
+            'hbapp_honeybadger_php_enabled' => 1,
+            'hbapp_honeybadger_php_api_key' => 'dummy-key',
+            'hbapp_honeybadger_php_report_non_fatal' => 0,
+            'hbapp_honeybadger_php_send_test_notification' => 0,
+            'hbapp_honeybadger_php_capture_deprecations' => 0,
+            'hbapp_honeybadger_js_send_test_notification' => 0,
+        ] );
+
+        $prev = error_reporting();
+        error_reporting( E_ALL );
+
+        $history = [];
+        add_filter('hbapp_honeybadger_http_client', function($client, $config) use (&$history) {
+            $mock = new \GuzzleHttp\Handler\MockHandler([
+            ]);
+            $handlerStack = \GuzzleHttp\HandlerStack::create($mock);
+
+            // Record all requests in $history so we can assert they were made.
+            $historyMiddleware = \GuzzleHttp\Middleware::history($history);
+            $handlerStack->push($historyMiddleware);
+
+            return new \GuzzleHttp\Client([
+                'handler' => $handlerStack,
+                'base_uri' => $config['endpoint'] ?? 'https://api.honeybadger.io/'
+            ]);
+        }, 10, 2);
+        $plugin = new HBAPP_Honeybadger();
+        $plugin->boot();
+
+        trigger_error( 'Test user warning: report non-fatal is false', E_USER_WARNING );
+
+        error_reporting( $prev );
+
+        $this->assertCount( 0, $history, 'Did not expect a warning to be reported when non-fatal reporting is disabled.' );
     }
 }

--- a/tests/test-honeybadger-settings.php
+++ b/tests/test-honeybadger-settings.php
@@ -97,7 +97,7 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         $this->assertSame( 'dummy-key-for-tests', $opts['hbapp_honeybadger_php_api_key'] );
 
         // Assert: the mock HTTP client was called to send the test notification.
-        $this->assertGreaterThanOrEqual( 1, count( $history ), 'Expected at least one HTTP request to Honeybadger.' );
+        $this->assertCount( 1, $history, 'Expected at least one HTTP request to Honeybadger.' );
         $transaction = $history[0];
         $this->assertArrayHasKey( 'request', $transaction );
         $request = $transaction['request'];
@@ -157,7 +157,7 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         error_reporting( E_ALL );
 
         $history = [];
-        add_filter('hbapp_honeybadger_http_client', function($client, $config) use (&$history) {
+        add_filter('hbapp_honeybadger_http_client', function(?\GuzzleHttp\Client $client, array $config) use (&$history) {
             $mock = new \GuzzleHttp\Handler\MockHandler([
                 new \GuzzleHttp\Psr7\Response(201, [], json_encode(['id' => 'test']))
             ]);
@@ -181,7 +181,7 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         // Restore error_reporting
         error_reporting( $prev );
 
-        $this->assertGreaterThanOrEqual( 1, count( $history ), 'Expected a deprecation to be reported to Honeybadger.' );
+        $this->assertCount( 1, $history, 'Expected a deprecation to be reported to Honeybadger.' );
         $this->assertSame( 'POST', $history[0]['request']->getMethod() );
         $this->assertSame( '/v1/notices', $history[0]['request']->getUri()->getPath() );
     }
@@ -236,7 +236,7 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         error_reporting( E_ALL );
 
         $history = [];
-        add_filter('hbapp_honeybadger_http_client', function($client, $config) use (&$history) {
+        add_filter('hbapp_honeybadger_http_client', function(?\GuzzleHttp\Client $client, array $config) use (&$history) {
             $mock = new \GuzzleHttp\Handler\MockHandler([
                 new \GuzzleHttp\Psr7\Response(201, [], json_encode(['id' => 'test']))
             ]);
@@ -258,7 +258,7 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
 
         error_reporting( $prev );
 
-        $this->assertSame( 1, count( $history ), 'Expected a single warning to be reported to Honeybadger.' );
+        $this->assertCount( 1, $history, 'Expected a single warning to be reported to Honeybadger.' );
         $this->assertSame( 'POST', $history[0]['request']->getMethod() );
         $this->assertSame( '/v1/notices', $history[0]['request']->getUri()->getPath() );
     }
@@ -280,7 +280,7 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         error_reporting( E_ALL );
 
         $history = [];
-        add_filter('hbapp_honeybadger_http_client', function($client, $config) use (&$history) {
+        add_filter('hbapp_honeybadger_http_client', function(?\GuzzleHttp\Client $client, array $config) use (&$history) {
             $mock = new \GuzzleHttp\Handler\MockHandler([
             ]);
             $handlerStack = \GuzzleHttp\HandlerStack::create($mock);

--- a/tests/test-honeybadger-settings.php
+++ b/tests/test-honeybadger-settings.php
@@ -22,6 +22,8 @@ class Honeybadger_Settings_Test extends WP_UnitTestCase {
         restore_error_handler();
         restore_exception_handler();
 
+        wp_set_current_user( 0 );
+
         parent::tear_down();
     }
 


### PR DESCRIPTION
Closes #3.

Changes:
- Organizes settings page to 2 sections: PHP and JS settings
- Modifies the composer install command to skip dev deps and adds the --optimize-autoloader flag
- Wraps client->notify in a try catch block and displays an admin notice in case of an error/exception
- Unsets the "send test notification" flag before actually attempting to send the test notification. This is a key change because if sending the notification fails and throws (or in worst-case scenarios, crashes the app), we end up in a case where we try to send the test notification on every page load, resulting in a crash loop
- Switched from `setUp` to `set_up` for tests, as per WordPress testing guidelines

Additionally, this PR adds the following options:
- Report non-fatal PHP errors (defaults to false)
- Report PHP deprecations (defaults to false)

<img width="2496" height="1444" alt="CleanShot 2025-08-21 at 00 52 29@2x" src="https://github.com/user-attachments/assets/7240386c-a70d-4779-b816-2a852cc1b692" />